### PR TITLE
Versión 1.2.0 - CRUD de Categorías y asignación en tareas

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,8 +5,4 @@ export const routes: Routes = [
     path: '',
     loadChildren: () => import('./shared/pages/tabs/tabs.routes').then((m) => m.routes),
   },
-  {
-    path: 'categorias',
-    loadComponent: () => import('./modules/categorias/pages/categorias/categorias.page').then( m => m.CategoriasPage)
-  },
 ];

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,4 +5,8 @@ export const routes: Routes = [
     path: '',
     loadChildren: () => import('./shared/pages/tabs/tabs.routes').then((m) => m.routes),
   },
+  {
+    path: 'categorias',
+    loadComponent: () => import('./modules/categorias/pages/categorias/categorias.page').then( m => m.CategoriasPage)
+  },
 ];

--- a/src/app/core/models/categoria.model.ts
+++ b/src/app/core/models/categoria.model.ts
@@ -1,0 +1,9 @@
+export class Categoria {
+    id: number;
+    nombre: string;
+  
+    constructor(nombre: string) {
+      this.id = new Date().getTime();
+      this.nombre = nombre;
+    }
+  }

--- a/src/app/core/models/tarea.model.ts
+++ b/src/app/core/models/tarea.model.ts
@@ -4,12 +4,14 @@ export class Tarea{
     fechaInicio: string;
     fechaCompletada: string | null;
     completada: boolean;
+    categoriaId: number | null;
 
-    constructor(descripcion:string){
+    constructor(descripcion:string, categoriaId: number | null = null){
         this.id = new Date().getTime()
         this.descripcion = descripcion
         this.fechaInicio = new Date().toISOString().split('T')[0].split('-').reverse().join('-') + ' ' + new Date().getHours() + ':' + new Date().getMinutes()
         this.fechaCompletada = null
         this.completada = false
+        this.categoriaId = categoriaId;
     }
 }

--- a/src/app/core/services/categoria.service.ts
+++ b/src/app/core/services/categoria.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { Categoria } from '../models/categoria.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CategoriaService {
+
+  constructor() { }
+
+  listaCategorias: Categoria[] = [];
+
+
+  cargarCategorias() {
+    if (localStorage.getItem('categorias')) {
+      this.listaCategorias = JSON.parse( localStorage.getItem('categorias')! )
+    }else{
+      this.listaCategorias = []
+    }
+  }
+
+  guardarCategorias() {
+    localStorage.setItem('categorias', JSON.stringify(this.listaCategorias));
+  }
+
+  crearCategoria(nombre: string) {
+    this.listaCategorias.push(new Categoria(nombre));
+    this.guardarCategorias();
+  }
+
+  eliminarCategoria(id: number) {
+    this.listaCategorias = this.listaCategorias.filter(categoria => categoria.id !== id);
+    this.guardarCategorias();
+  }
+
+  editarCategoria(id: number, nuevoNombre: string) {
+    const categoria = this.listaCategorias.find(c => c.id === id);
+    if (categoria) {
+      categoria.nombre = nuevoNombre;
+      this.guardarCategorias();
+    }
+  }
+}

--- a/src/app/core/services/categoria.service.ts
+++ b/src/app/core/services/categoria.service.ts
@@ -6,7 +6,9 @@ import { Categoria } from '../models/categoria.model';
 })
 export class CategoriaService {
 
-  constructor() { }
+  constructor() { 
+    this.cargarCategorias()
+  }
 
   listaCategorias: Categoria[] = [];
 

--- a/src/app/core/services/tarea.service.ts
+++ b/src/app/core/services/tarea.service.ts
@@ -21,8 +21,8 @@ export class TareaService {
     }
   }
 
-  crearTarea(descripcion:string){
-    this.listaTareas.push(new Tarea(descripcion))
+  crearTarea(descripcion:string, categoriaId: number){
+    this.listaTareas.push(new Tarea(descripcion, categoriaId))
     this.guardarTarea()
   }
 

--- a/src/app/modules/categorias/components/lista-categoria/lista-categoria.page.html
+++ b/src/app/modules/categorias/components/lista-categoria/lista-categoria.page.html
@@ -1,0 +1,22 @@
+<ion-list>
+
+  <ion-item-sliding *ngFor="let categoria of _categoriaService.listaCategorias">
+    <ion-item-options side="start">
+      <ion-item-option color="secondary" (click)="editarCategoria( categoria )">
+        <ion-icon name="create-outline" slot="icon-only"></ion-icon>
+      </ion-item-option>
+    </ion-item-options>
+
+    <ion-item>
+      <ion-label slot="start">{{ categoria.nombre | titlecase}}</ion-label>
+    </ion-item>
+    
+
+    <ion-item-options side="end">
+      <ion-item-option color="danger" (click)="eliminarcategoria( categoria )">
+        <ion-icon name="trash-outline" slot="icon-only"></ion-icon>
+      </ion-item-option>
+    </ion-item-options>
+  </ion-item-sliding>
+
+</ion-list>

--- a/src/app/modules/categorias/components/lista-categoria/lista-categoria.page.ts
+++ b/src/app/modules/categorias/components/lista-categoria/lista-categoria.page.ts
@@ -1,0 +1,62 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { IonList, IonLabel, IonItem, IonItemSliding, IonItemOptions, IonItemOption, IonIcon } from '@ionic/angular/standalone';
+import { CategoriaService } from 'src/app/core/services/categoria.service';
+import { AlertController } from '@ionic/angular/standalone';
+import { Categoria } from 'src/app/core/models/categoria.model';
+
+@Component({
+  selector: 'app-lista-categoria',
+  templateUrl: './lista-categoria.page.html',
+  styleUrls: ['./lista-categoria.page.scss'],
+  standalone: true,
+  imports: [IonIcon, IonItemOption, IonItemOptions, IonItemSliding, IonItem, IonLabel, IonList, CommonModule, FormsModule]
+})
+export class ListaCategoriaPage{
+
+  @ViewChild(IonList) ionList!: IonList
+
+  constructor(public _categoriaService:CategoriaService, private _alertController:AlertController) { }
+
+  async editarCategoria( categoria:Categoria ){
+    const alerta = await this._alertController.create({
+      header: 'Editar categoria',
+      inputs:[
+        {
+          name: 'nombre',
+          placeholder: 'Nuevo nombre',
+          type: 'text',
+          value: categoria.nombre
+        },
+      ],
+      buttons: [
+        {
+          text: 'Cancelar',
+          role: 'cancel',
+          handler: () => {
+            this.ionList.closeSlidingItems()
+          }
+        },
+        {
+          text: 'Actualizar',
+          role: 'confirm',
+          handler: ( data ) => {
+            if (data.nombre.length === 0) {
+              this.ionList.closeSlidingItems()
+              return;
+            }
+            this._categoriaService.editarCategoria(categoria.id, data.nombre)
+            this.ionList.closeSlidingItems()
+          },
+        }
+      ],
+    })
+
+    alerta.present()
+  }
+
+  eliminarcategoria( categoria:Categoria ){
+    this._categoriaService.eliminarCategoria(categoria.id)
+  }
+}

--- a/src/app/modules/categorias/pages/categorias/categorias.page.html
+++ b/src/app/modules/categorias/pages/categorias/categorias.page.html
@@ -1,0 +1,13 @@
+<ion-header [translucent]="true">
+  <ion-toolbar>
+    <ion-title>categorias</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content [fullscreen]="true">
+  <ion-header collapse="condense">
+    <ion-toolbar>
+      <ion-title size="large">categorias</ion-title>
+    </ion-toolbar>
+  </ion-header>
+</ion-content>

--- a/src/app/modules/categorias/pages/categorias/categorias.page.html
+++ b/src/app/modules/categorias/pages/categorias/categorias.page.html
@@ -1,13 +1,17 @@
-<ion-header [translucent]="true">
-  <ion-toolbar>
-    <ion-title>categorias</ion-title>
+<ion-header [translucent]="true" class="ion-no-border">
+  <ion-toolbar color="primary">
+    <ion-title>Mis Categorias</ion-title>
   </ion-toolbar>
 </ion-header>
 
 <ion-content [fullscreen]="true">
-  <ion-header collapse="condense">
-    <ion-toolbar>
-      <ion-title size="large">categorias</ion-title>
-    </ion-toolbar>
-  </ion-header>
+  <app-lista-categoria>
+  
+  </app-lista-categoria>
+
+  <ion-fab  slot="fixed" vertical="bottom" horizontal="end">
+    <ion-fab-button (click)="agregarCategoria()">
+      <ion-icon name="add-outline"></ion-icon>
+    </ion-fab-button>
+  </ion-fab>
 </ion-content>

--- a/src/app/modules/categorias/pages/categorias/categorias.page.ts
+++ b/src/app/modules/categorias/pages/categorias/categorias.page.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-categorias',
+  templateUrl: './categorias.page.html',
+  styleUrls: ['./categorias.page.scss'],
+  standalone: true,
+  imports: [IonContent, IonHeader, IonTitle, IonToolbar, CommonModule, FormsModule]
+})
+export class CategoriasPage implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/modules/categorias/pages/categorias/categorias.page.ts
+++ b/src/app/modules/categorias/pages/categorias/categorias.page.ts
@@ -1,20 +1,54 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonTitle, IonToolbar, IonFabButton, IonFab, IonIcon } from '@ionic/angular/standalone';
+import { ListaCategoriaPage } from '../../components/lista-categoria/lista-categoria.page';
+import { CategoriaService } from 'src/app/core/services/categoria.service';
+import { AlertController } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-categorias',
   templateUrl: './categorias.page.html',
   styleUrls: ['./categorias.page.scss'],
   standalone: true,
-  imports: [IonContent, IonHeader, IonTitle, IonToolbar, CommonModule, FormsModule]
+  imports: [IonIcon, IonFab, IonFabButton, ListaCategoriaPage, IonContent, IonHeader, IonTitle, IonToolbar, CommonModule, FormsModule]
 })
 export class CategoriasPage implements OnInit {
 
-  constructor() { }
+  constructor(private _categoriaService:CategoriaService, private _alertController:AlertController) { }
 
   ngOnInit() {
+  }
+
+  async agregarCategoria(){
+    const alerta = await this._alertController.create({
+      header: 'Crear una nueva categoria',
+      inputs:[
+        {
+          name: 'nombre',
+          placeholder: 'Nombre de la categoria',
+          type: 'text',
+        },
+      ],
+      buttons: [
+        {
+          text: 'Cancelar',
+          role: 'cancel',
+        },
+        {
+          text: 'Agregar',
+          role: 'confirm',
+          handler: ( data ) => {
+            if (data.nombre.length === 0) {
+              return;
+            }
+            this._categoriaService.crearCategoria(data.nombre)
+          },
+        }
+      ],
+    })
+
+    alerta.present()
   }
 
 }

--- a/src/app/modules/categorias/pages/categorias/categorias.routes.ts
+++ b/src/app/modules/categorias/pages/categorias/categorias.routes.ts
@@ -1,0 +1,9 @@
+import { Routes } from "@angular/router";
+import { CategoriasPage } from "./categorias.page";
+
+export const routes:Routes = [
+    {
+        path: '',
+        component: CategoriasPage
+    }
+]

--- a/src/app/modules/tareas/pages/completadas/completadas.page.html
+++ b/src/app/modules/tareas/pages/completadas/completadas.page.html
@@ -1,6 +1,6 @@
 <ion-header [translucent]="true" class="ion-no-border">
   <ion-toolbar color="primary">
-    <ion-title>Tareas completadas</ion-title>
+    <ion-title>Mis Tareas Completadas</ion-title>
   </ion-toolbar>
 </ion-header>
 

--- a/src/app/modules/tareas/pages/pendientes/pendientes.page.html
+++ b/src/app/modules/tareas/pages/pendientes/pendientes.page.html
@@ -1,6 +1,6 @@
 <ion-header [translucent]="true" class="ion-no-border">
   <ion-toolbar color="primary">
-    <ion-title>Mis tareas</ion-title>
+    <ion-title>Mis Tareas Pendientes</ion-title>
   </ion-toolbar>
 </ion-header>
 

--- a/src/app/shared/components/lista-tareas/lista-tareas.page.html
+++ b/src/app/shared/components/lista-tareas/lista-tareas.page.html
@@ -8,7 +8,11 @@
     </ion-item-options>
 
     <ion-item (click)="completarTarea(tarea)">
-      <ion-label slot="start">{{ tarea.descripcion | titlecase }}</ion-label>
+      <ion-label slot="start">
+        <ion-badge color="secondary" *ngIf="tarea.categoriaId === null">Sin categoria</ion-badge>
+        <ion-badge color="secondary" *ngIf="tarea.categoriaId != null">{{obtenerNombreCategoria(tarea.categoriaId)}}</ion-badge>
+        <p>{{ tarea.descripcion | titlecase }}</p>
+      </ion-label>
       <ion-note slot="end" *ngIf="tarea.completada">{{tarea.fechaCompletada}}</ion-note>
       <ion-note slot="end" *ngIf="!tarea.completada">{{tarea.fechaInicio}}</ion-note>
     </ion-item>

--- a/src/app/shared/components/lista-tareas/lista-tareas.page.html
+++ b/src/app/shared/components/lista-tareas/lista-tareas.page.html
@@ -8,7 +8,7 @@
     </ion-item-options>
 
     <ion-item (click)="completarTarea(tarea)">
-      <ion-label slot="start">{{ tarea.descripcion }}</ion-label>
+      <ion-label slot="start">{{ tarea.descripcion | titlecase }}</ion-label>
       <ion-note slot="end" *ngIf="tarea.completada">{{tarea.fechaCompletada}}</ion-note>
       <ion-note slot="end" *ngIf="!tarea.completada">{{tarea.fechaInicio}}</ion-note>
     </ion-item>

--- a/src/app/shared/components/lista-tareas/lista-tareas.page.ts
+++ b/src/app/shared/components/lista-tareas/lista-tareas.page.ts
@@ -1,26 +1,27 @@
 import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { IonList, IonItemSliding, IonItemOptions, IonItemOption, IonIcon, IonItem, IonLabel, IonButton, IonNote } from '@ionic/angular/standalone';
+import { IonList, IonItemSliding, IonItemOptions, IonItemOption, IonIcon, IonItem, IonLabel, IonButton, IonNote, IonBadge } from '@ionic/angular/standalone';
 import { TareaService } from 'src/app/core/services/tarea.service';
 import { addIcons } from 'ionicons';
 import {  createOutline, trashOutline } from 'ionicons/icons';
 import { Tarea } from 'src/app/core/models/tarea.model';
 import { AlertController } from '@ionic/angular/standalone';
 import { TareaCompletadaPipe } from 'src/app/core/pipes/tarea-completada.pipe';
+import { CategoriaService } from 'src/app/core/services/categoria.service';
 
 @Component({
   selector: 'app-lista-tareas',
   templateUrl: './lista-tareas.page.html',
   styleUrls: ['./lista-tareas.page.scss'],
   standalone: true,
-  imports: [IonNote, TareaCompletadaPipe, IonList, IonIcon, IonItemOption, IonItemOptions, IonLabel, IonItem, IonItemSliding, CommonModule]
+  imports: [IonBadge, IonNote, TareaCompletadaPipe, IonList, IonIcon, IonItemOption, IonItemOptions, IonLabel, IonItem, IonItemSliding, CommonModule]
 })
 export class ListaTareasPage implements OnInit {
 
   @Input() completada:boolean = false
   @ViewChild(IonList) ionList!: IonList
 
-  constructor(public _tareaService: TareaService, private alertController: AlertController) {
+  constructor(public _tareaService: TareaService, private alertController: AlertController, private _categoriaService: CategoriaService) {
     addIcons({createOutline,trashOutline});
    }
 
@@ -58,13 +59,25 @@ export class ListaTareasPage implements OnInit {
   }
 
   async editarTarea( tarea:Tarea ){
+    if (this._categoriaService.listaCategorias.length === 0) {
+      const alerta = await this.alertController.create({
+        header: 'No existen categorías',
+        message: 'Debes crear al menos una categoría antes de editar tareas.',
+        buttons: ['OK'],
+      });
+  
+      alerta.present();
+
+      return;
+    }
+
     const alerta = await this.alertController.create({
       header: 'Editar tarea',
       inputs:[
         {
           name: 'descripcion',
-          placeholder: 'Nueva descripcion',
           type: 'text',
+          placeholder: 'Descripción de la tarea',
           value: tarea.descripcion
         },
       ],
@@ -72,21 +85,43 @@ export class ListaTareasPage implements OnInit {
         {
           text: 'Cancelar',
           role: 'cancel',
-          handler: () => {
+          handler: () =>{
             this.ionList.closeSlidingItems()
           }
         },
         {
-          text: 'Actualizar',
+          text: 'Continuar',
           role: 'confirm',
-          handler: ( data ) => {
-            if (data.descripcion.length === 0) {
-              this.ionList.closeSlidingItems()
-              return;
-            }
-            tarea.descripcion = data.descripcion
-            this._tareaService.guardarTarea()
-            this.ionList.closeSlidingItems()
+          handler: async ( data ) => {
+            if(!data.descripcion){return}
+
+            const categoriaAlert = await this.alertController.create({
+              header: 'Elige la categoría',
+              inputs: [
+                ...this._categoriaService.listaCategorias.map((categoria) => ({
+                  type: 'radio' as const,
+                  label: categoria.nombre,
+                  value: categoria.id,
+                })),
+              ],
+              buttons: [
+                {
+                  text: 'Cancelar',
+                  role: 'cancel',
+                },
+                {
+                  text: 'Guardar',
+                  handler: (catId) => {
+                    tarea.descripcion = data.descripcion
+                    tarea.categoriaId = catId
+                    this._tareaService.guardarTarea()
+                    this.ionList.closeSlidingItems()
+                  },
+                },
+              ],
+            });
+    
+            categoriaAlert.present();
           },
         }
       ],
@@ -99,6 +134,8 @@ export class ListaTareasPage implements OnInit {
     this._tareaService.eliminarTarea(tarea.id)
   }
 
-
+  obtenerNombreCategoria(categoriaId: number | null){
+    return this._categoriaService.listaCategorias.find(categoria => categoria.id === categoriaId)?.nombre
+  }
 
 }

--- a/src/app/shared/pages/tabs/tabs.page.html
+++ b/src/app/shared/pages/tabs/tabs.page.html
@@ -4,6 +4,10 @@
       <ion-icon aria-hidden="true" name="clipboard-outline"></ion-icon>
     </ion-tab-button>
 
+    <ion-tab-button tab="categorias" href="/tabs/categorias">
+      <ion-icon aria-hidden="true" name="grid-outline"></ion-icon>
+    </ion-tab-button>
+
     <ion-tab-button tab="completadas" href="/tabs/completadas">
       <ion-icon aria-hidden="true" name="bookmark-outline"></ion-icon>
     </ion-tab-button>

--- a/src/app/shared/pages/tabs/tabs.page.ts
+++ b/src/app/shared/pages/tabs/tabs.page.ts
@@ -1,7 +1,7 @@
 import { Component, EnvironmentInjector, inject, OnInit } from '@angular/core';
 import { IonTabs, IonTabBar, IonTabButton, IonIcon, IonLabel } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
-import { bookmarkOutline, clipboardOutline } from 'ionicons/icons';
+import { bookmarkOutline, clipboardOutline, gridOutline } from 'ionicons/icons';
 
 @Component({
   selector: 'app-tabs',
@@ -15,7 +15,7 @@ export class TabsPage{
   public environmentInjector = inject(EnvironmentInjector);
 
   constructor() {
-    addIcons({ clipboardOutline, bookmarkOutline });
+    addIcons({clipboardOutline,gridOutline,bookmarkOutline});
   }
 
 }

--- a/src/app/shared/pages/tabs/tabs.routes.ts
+++ b/src/app/shared/pages/tabs/tabs.routes.ts
@@ -18,6 +18,10 @@ export const routes:Routes = [
             {
                 path: 'completadas',
                 loadChildren: () => import('../../../modules/tareas/pages/completadas/completadas.routes').then((m)=>m.routes)
+            },
+            {
+                path: 'categorias',
+                loadChildren: () => import('../../../modules/categorias/pages/categorias/categorias.routes').then((m)=>m.routes)
             }
         ]
     },


### PR DESCRIPTION
**Cambios incluidos:**
- Agregado módulo de categorías con CRUD completo.
- Permite asignar categoría al crear tareas.
- Visualización de categoría en la lista de tareas.
- Manejo de tareas sin categoría.
- Persistencia en localStorage.

**Cómo probarlo:**
- Crear una nueva categoría.
- Crear tareas desde el tab principal y asignar categoría.
- Editar tareas para cambiarles la categoría.